### PR TITLE
Remove validation image

### DIFF
--- a/Dockerfile.dd
+++ b/Dockerfile.dd
@@ -12,7 +12,7 @@ ADD . .
 RUN GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') GCE_PD_CSI_STAGING_VERSION=$STAGINGVERSION make gce-pd-driver
 
 # Start from BASE_IMAGE.
-FROM $BASE_IMAGE as output-image
+FROM $BASE_IMAGE
 
 # Install necessary dependencies
 # google_nvme_id script depends on the following packages: nvme-cli, xxd, bash
@@ -22,17 +22,5 @@ USER dog
 
 # Copy NVME support required script and rules into base image.
 COPY deploy/kubernetes/udev/google_nvme_id /lib/udev_containerized/google_nvme_id
-
-# Build stage used for validation of the output-image
-# See validate-container-linux-* targets in Makefile
-FROM output-image as validation-image
-
-COPY --from=output-image /usr/bin/ldd /usr/bin/find /usr/bin/xargs /usr/bin/
-COPY --from=builder /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/hack/print-missing-deps.sh /print-missing-deps.sh
-SHELL ["/bin/bash", "-c"]
-RUN /print-missing-deps.sh
-
-# Final build stage, create the real Docker image with ENTRYPOINT
-FROM output-image
 
 ENTRYPOINT ["/gce-pd-csi-driver"]


### PR DESCRIPTION
We actually don't need to check if libraries are present as we install the required binaries using apt instead of cherry-picking libs and binaries from a different image.