### PR TITLE
[metrics] Fix panic during metrics manager startup

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -38,11 +38,6 @@ const (
 )
 
 var (
-	gkeComponentVersion        *metrics.GaugeVec
-	pdcsiOperationErrorsMetric *metrics.CounterVec
-)
-
-func initMetrics() {
 	// This metric is exposed only from the controller driver component when GKE_PDCSI_VERSION env variable is set.
 	gkeComponentVersion = metrics.NewGaugeVec(&metrics.GaugeOpts{
 		Name: "component_version",
@@ -57,7 +52,7 @@ func initMetrics() {
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"driver_name", "method_name", "grpc_status_code", "disk_type", "enable_confidential_storage", "enable_storage_pools"})
-}
+)
 
 type MetricsManager struct {
 	registry metrics.KubeRegistry

--- a/pkg/metrics/metrics_test_util.go
+++ b/pkg/metrics/metrics_test_util.go
@@ -19,5 +19,6 @@ package metrics
 // Test-only method used for resetting metric counts.
 func (mm *MetricsManager) ResetMetrics() {
 	// Re-initialize metrics
-	initMetrics()
+	gkeComponentVersion.Reset()
+	pdcsiOperationErrorsMetric.Reset()
 }


### PR DESCRIPTION
This fixes a regression introduced in #1876 where the driver would start panicking on startup if `--http-endpoint` was specified. This was caused by the metrics not being initialized anymore during startup. The proposed fix involves using the `Reset` methods of the metrics object instead of trying to redefine them each time they need to be reset.

Fix is open upstream https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1895 but let's fix it here first 