### PR TITLE
[local] Set GOTOOLCHAIN: "auto" in test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,8 @@ test:
   image: registry.ddbuild.io/images/mirror/golang:1.24.0
   script:
     - cd pkg && go test ./... -v
+  variables:
+    GOTOOLCHAIN: "auto"
 
 build-docker-image:
   variables:


### PR DESCRIPTION
So that test can run if the original CI image uses a lower go version